### PR TITLE
cocos2d-x v3 での描画コマンド形式へ対応させた。シェーダーはGLProgramStateで処理させるように変更。カスタムシェー…

### DIFF
--- a/Players/Cocos2d-x_v3/SS5Player.cpp
+++ b/Players/Cocos2d-x_v3/SS5Player.cpp
@@ -3486,12 +3486,12 @@ void CustomSprite::changeShaderProgram(bool useCustomShaderProgram)
 				shaderProgram = _defaultShaderProgram;
 				useCustomShaderProgram = false;
 			}
-            this->setGLProgramState(cocos2d::GLProgramState::getOrCreateWithGLProgram(shaderProgram));
+            this->setGLProgram(shaderProgram);
 			_useCustomShaderProgram = useCustomShaderProgram;
 		}
 		else
 		{
-            this->setGLProgramState(cocos2d::GLProgramState::getOrCreateWithGLProgram(_defaultShaderProgram));
+            this->setGLProgram(_defaultShaderProgram);
 			_useCustomShaderProgram = false;
 		}
 	}

--- a/Players/Cocos2d-x_v3/SS5Player.h
+++ b/Players/Cocos2d-x_v3/SS5Player.h
@@ -156,10 +156,6 @@ struct State
 class CustomSprite : public cocos2d::Sprite
 {
 private:
-	static unsigned int ssSelectorLocation;
-	static unsigned int	ssAlphaLocation;
-	static unsigned int	sshasPremultipliedAlpha;
-
 	static cocos2d::GLProgram* getCustomShaderProgram();
 
 private:


### PR DESCRIPTION
cocos2d-x v3 での描画コマンド形式へ対応させたものです。
シェーダー管理はGLProgramStateで処理させるように変更。
それとともに、uniformはGLProgramStateのAPIで行った。

カスタムシェーダー側の動作は、サンプルにテスト用データが無かったため、ある程度のチェック(パラメーターがちゃんと渡っているなど)を行ったのみ。
申し訳ないです。

頂点シェーダーに渡しているシェーダーが、MVPマトリクスを計算するようになっていたため、VPマトリクスのみへ修正。
